### PR TITLE
fix typos in error messages

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,7 +76,7 @@ func (c *Config) SetupListener(fallback func(err error)) *Config {
 // feedStruct feeds a struct using given feeder.
 func (c *Config) feedStruct(f Feeder, s interface{}) error {
 	if err := f.Feed(s); err != nil {
-		return fmt.Errorf("config: faild to feed struct; err %v", err)
+		return fmt.Errorf("config: failed to feed struct; err %v", err)
 	}
 
 	return nil

--- a/pkg/feeder/dotenv.go
+++ b/pkg/feeder/dotenv.go
@@ -16,7 +16,7 @@ type DotEnv struct {
 func (f DotEnv) Feed(structure interface{}) error {
 	file, err := os.Open(filepath.Clean(f.Path))
 	if err != nil {
-		return fmt.Errorf("config: cannot open json file; err: %v", err)
+		return fmt.Errorf("config: cannot open env file; err: %v", err)
 	}
 
 	if err = dotenv.NewDecoder(file).Decode(structure); err != nil {

--- a/pkg/feeder/toml.go
+++ b/pkg/feeder/toml.go
@@ -16,7 +16,7 @@ type Toml struct {
 func (f Toml) Feed(structure interface{}) error {
 	file, err := os.Open(filepath.Clean(f.Path))
 	if err != nil {
-		return fmt.Errorf("config: cannot open json file; err: %v", err)
+		return fmt.Errorf("config: cannot open toml file; err: %v", err)
 	}
 
 	if _, err = toml.NewDecoder(file).Decode(structure); err != nil {

--- a/pkg/feeder/yaml.go
+++ b/pkg/feeder/yaml.go
@@ -16,7 +16,7 @@ type Yaml struct {
 func (f Yaml) Feed(structure interface{}) error {
 	file, err := os.Open(filepath.Clean(f.Path))
 	if err != nil {
-		return fmt.Errorf("config: cannot open json file; err: %v", err)
+		return fmt.Errorf("config: cannot open yaml file; err: %v", err)
 	}
 
 	if err = yaml.NewDecoder(file).Decode(structure); err != nil {


### PR DESCRIPTION
Just a small update - errors were all saying "json" even for other feeders like toml and dotenv